### PR TITLE
Add function name to log output

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function(params, opts) {
 	}, opts);
 
 	var toUpload;
+	var functionName = typeof params === 'string'? params : params.FunctionName;
 
 	var make_err = function(message) {
 		return new gutil.PluginError('gulp-awslambda', message);
@@ -39,7 +40,7 @@ module.exports = function(params, opts) {
 			return;
 		}
 
-		gutil.log('Uploading Lambda function "' + params.FunctionName + '"...');
+		gutil.log('Uploading Lambda function "' + functionName + '"...');
 
 		if (opts.profile !== null) {
 			AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: opts.profile });
@@ -55,7 +56,7 @@ module.exports = function(params, opts) {
 				cb(make_err(err.message));
 				return;
 			}
-			gutil.log('Lambda function "' + params.FunctionName + '" successfully uploaded');
+			gutil.log('Lambda function "' + functionName + '" successfully uploaded');
 			stream.push(toUpload);
 			cb();
 		};

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(params, opts) {
 			return;
 		}
 
-		gutil.log('Uploading Lambda function...');
+		gutil.log('Uploading Lambda function "' + params.FunctionName + '"...');
 
 		if (opts.profile !== null) {
 			AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: opts.profile });
@@ -55,7 +55,7 @@ module.exports = function(params, opts) {
 				cb(make_err(err.message));
 				return;
 			}
-			gutil.log('Lambda function successfully uploaded');
+			gutil.log('Lambda function "' + params.FunctionName + '" successfully uploaded');
 			stream.push(toUpload);
 			cb();
 		};


### PR DESCRIPTION
When uploading different functions from the same project / same gulp task, it is handy to know which ones are currently being uploaded.  This PR simply adds the name of the lambda function (as provided in `FunctionName`) to the start and finish log messages.
The new message would appear as:

```
Uploading Lambda function "myLambdaFn"...
Lambda function "myLambdaFn" successfully uploaded
```

where `myLambdaFn` is the name of the current Lambda function being uploaded.
