### PR TITLE
Code in params cannot be accepted by lambda.updateFunctionConfiguration

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,9 @@ module.exports = function(params, opts) {
 						if (err) {
 							return done(err);
 						}
+						if (params.hasOwnProperty('Code')) {
+							delete params['Code'];
+						}
 						lambda.updateFunctionConfiguration(params, done);
 					});
 				}


### PR DESCRIPTION
When setting Code in parameters like:

```
Code: {
S3Bucket: 'myBucket',
S3Key: 'function.zip',
}
```

there is an error says :Unexpected key 'Code' found in params .
The root cause is that `updateFunctionConfiguration` has no idea about ‘Code'. 
Then this change is to remove 'Code' before calling `updateFunctionConfiguration`.
